### PR TITLE
Update Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,6 +7,6 @@ WriteMakefile(
     VERSION_FROM      => 'lib/PerlMon/Distro.pm', # finds $VERSION
     PREREQ_PM         => {}, # e.g., Module::Name => 1.1
     ($] >= 5.005 ?     ## Add these new keywords supported since 5.005
-      (ABSTRACT_FROM  => 'lib/PerlMon/Distro.pm', # retrieve abstract from module
+      (ABSTRACT       => 'lib/PerlMon/Distro.pm', # retrieve abstract from module
        AUTHOR         => 'A. U. Thor <anomaly@slackware.lan>') : ()),
 );


### PR DESCRIPTION
fix WARNING: Setting ABSTRACT via file 'lib/PerlMon/Distro.pm' failed at /usr/share/perl/5.22/ExtUtils/MakeMaker.pm line 663.
